### PR TITLE
fix github button link

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -10,7 +10,7 @@
   </nz-content>
   <nz-footer>
   	<ntkme-github-button
-	  user="ackao"
+	  user="axheron"
 	  repo="ffxiv-dps-calc"
 	  [standardIcon]=true
 	  size="large"


### PR DESCRIPTION
i'm going to fully admit right now that this is untested.

it should change the frontend gh issues button to point to axheron instead of ackao